### PR TITLE
Fix Azure deployment: exclude node_modules from artifact to preserve …

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: npm install, build, and test
       run: |
-        npm install
+        npm ci
         npm run build --if-present
         npm run test --if-present
 
@@ -52,7 +52,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: node-app
-        path: .
+        path: |
+          .
+          !node_modules
+          !.git
 
   deploy:
     permissions:


### PR DESCRIPTION
….bin symlinks

Uploading node_modules via ZIP deploy breaks npm binary symlinks, causing 'next: not found' at startup. Let Azure Oryx install dependencies on the server.

https://claude.ai/code/session_01Bhix7ewFEeAQMJe37JYaRq