### PR TITLE
Fix standalone deployment path: download artifact to explicit 'deploy…

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -24,7 +24,6 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: MPG-Fuel         # Azure App Service name
-  AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
   NODE_VERSION: '22.x'                # set this to the node version to use
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -74,6 +73,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: node-app
+        path: deploy
 
     - name: 'Deploy to Azure WebApp'
       id: deploy-to-webapp
@@ -81,4 +81,4 @@ jobs:
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        package: deploy


### PR DESCRIPTION
…' dir

upload-artifact preserves the .next/standalone/ path prefix, so server.js was landing at wwwroot/.next/standalone/server.js instead of wwwroot/server.js.

Explicitly downloading to 'deploy/' and deploying from 'deploy/' ensures server.js is always at the wwwroot root where 'node server.js' expects it.

https://claude.ai/code/session_01Bhix7ewFEeAQMJe37JYaRq