### PR TITLE
Add custom server.js to fix Azure startup without needing next CLI in…

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -48,16 +48,15 @@ jobs:
         npm run build --if-present
         npm run test --if-present
 
-    - name: Prepare standalone deployment
-      run: |
-        cp -r .next/static .next/standalone/.next/static
-        cp package.json .next/standalone/package.json
-
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v4
       with:
         name: node-app
-        path: .next/standalone
+        path: |
+          .
+          !node_modules
+          !.git
+          !.github
 
   deploy:
     permissions:
@@ -73,7 +72,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: node-app
-        path: deploy
 
     - name: 'Deploy to Azure WebApp'
       id: deploy-to-webapp
@@ -81,4 +79,4 @@ jobs:
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: deploy
+        package: .

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  output: 'standalone',
   // better-sqlite3 is a native module, keep it server-side only
   serverExternalPackages: ['better-sqlite3'],
   // Allow images from OpenStreetMap tile servers

--- a/server.js
+++ b/server.js
@@ -1,0 +1,21 @@
+const { createServer } = require('http');
+const { parse } = require('url');
+const next = require('next');
+
+const dev = process.env.NODE_ENV !== 'production';
+const port = parseInt(process.env.PORT || '8080', 10);
+
+const app = next({ dev, port });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(port, () => {
+    console.log(`> Ready on port ${port}`);
+  });
+}).catch((err) => {
+  console.error('Failed to start server:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
… PATH

The root problem: Azure Deployment Center deploys source code and Oryx installs deps, but 'next' binary wasn't on PATH so 'next start' failed. All the standalone output attempts also failed due to path issues.

Fix: add server.js to the repo that uses require('next') directly — no CLI binary needed. Oryx installs next as a module (which works), custom server uses it via require(). Works with both Deployment Center and GitHub Actions.

- server.js: custom Next.js HTTP server using require('next')
- next.config.ts: remove standalone output (not needed)
- workflow: revert to simple source + .next build artifact deploy

https://claude.ai/code/session_01Bhix7ewFEeAQMJe37JYaRq