### PR TITLE
Fix start script: invoke next directly via node to avoid PATH issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "node server.js",
+    "start": "node ./node_modules/next/dist/bin/next start",
     "lint": "next lint"
   },
   "engines": {


### PR DESCRIPTION
'next start' fails because Azure's Oryx puts node_modules in /node_modules and symlinks it, but the next binary isn't reliably on PATH for npm scripts.

Using 'node ./node_modules/next/dist/bin/next start' bypasses PATH entirely:
- node is always available
- ./node_modules is symlinked by Oryx startup to /node_modules
- No separate server.js file needed, no CLI binary resolution issues

https://claude.ai/code/session_01Bhix7ewFEeAQMJe37JYaRq