### PR TITLE
Fix server.js running in dev mode on Azure (Turbopack error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "node ./node_modules/next/dist/bin/next start",
+    "start": "node server.js",
     "lint": "next lint"
   },
   "engines": {

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const { createServer } = require('http');
 const { parse } = require('url');
 const next = require('next');
 
-const dev = process.env.NODE_ENV !== 'production';
+const dev = process.env.NODE_ENV === 'development';
 const port = parseInt(process.env.PORT || '8080', 10);
 
 const app = next({ dev, port });


### PR DESCRIPTION
Azure doesn't set NODE_ENV, so 'process.env.NODE_ENV !== production' evaluated to true, starting Next.js in dev mode with Turbopack. Turbopack then failed because node_modules is symlinked outside the project directory.

Change condition to 'NODE_ENV === development' so production is the default when NODE_ENV is unset. server.js finds the pre-built .next/ and serves it.

https://claude.ai/code/session_01Bhix7ewFEeAQMJe37JYaRq